### PR TITLE
Check if signature file exists

### DIFF
--- a/signapple/sign.py
+++ b/signapple/sign.py
@@ -1104,6 +1104,8 @@ def apply_sig(bins_path: str, sigs_path: str) -> SigningStatus:
     """
     bin_code_signers: Dict[str, CodeSigner] = {}
     sig_files = []
+    if not os.path.exists(sigs_path):
+        raise Exception("Signature file not found")
     if os.path.isfile(sigs_path):
         sig_files.append(sigs_path)
     else:


### PR DESCRIPTION
If a detached signature file is missing, `signapple apply FILE WRONG_SIGNATURE_PATH` throws a rather cryptic error:

```
  File "/gnu/store/40i4bf2wzcbjknfqnsdxpx9pf489bvjv-python-signapple-0.2.0-1.85bfcec/lib/python3.10/site-packages/signapple/__init__.py", line 38, in apply
    ret = apply_sig(args.filename, args.sig)
  File "/gnu/store/40i4bf2wzcbjknfqnsdxpx9pf489bvjv-python-signapple-0.2.0-1.85bfcec/lib/python3.10/site-packages/signapple/sign.py", line 1175, in apply_sig
    os.makedirs(os.path.dirname(file_out_path), exist_ok=True)
  File "/gnu/store/z193j1jnz80h56fbv6nic6mh34b4bb1j-python-3.10.7/lib/python3.10/os.py", line 225, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: 'WRONG_SIGNATURE_PATH'
````

Catch this situation early.